### PR TITLE
Fix Mobile Images, Alternate Images with CSS

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,20 +18,19 @@
   <div class="row">
     <div class="col-md-2">
       <div class="entry-sidebar">
-        CATEGORIES
+        <div class="entry-sidebar-title">CATEGORIES</div>
         {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
         <div class="entry-categories">
           <a href="{{ "/categories/" | relLangURL }}{{ $name | urlize }}">{{ $name }}</a>
         </div>
         {{ end }}
 
-        Tags
+        <div class="entry-sidebar-title">Tags</div>
         {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
         <div class="entry-tags">
           <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}">{{ $name }}</a>
         </div>
         {{ end }}
-
       </div>
     </div>
     <div class="col-md-10">

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -6,66 +6,33 @@
 
 <div class="row">
   <div class="col-md-10 category-description">
-  
+
   </div>
 </div>
 
 {{ range $index, $element := (where .Data.Pages "Section" "post") }}
-{{if mod (add $index 1) 2 }}
 <div class="row content">
   {{ if and (isset .Params "image") .Params.image }}
-  <div class="col-md-6 content-excerpt">
-    {{ else }}
-    <div class="col-md-12 content-excerpt">
-      {{end}}
-      <div class="row">
-        <div class="col-md-12">
-          <div class="row content-date">
-            {{ .Date.Format "January 06" }}
-          </div>
-          <div class="row content-title">
-            <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>
-          </div>
-          <div class="row content-summary">
-            <p> {{ .Summary }} </p>
-            <a class="more-link" href="{{ .Permalink }} "> READ THE POST </a>
-          </div>
-        </div>
-      </div>
-    </div>
-    {{ if and (isset .Params "image") .Params.image }}
-    <div class="col-md-6 content-image" style="background-image: url({{ .Params.image }})">
-    </div>
-    {{ end }}
+  <div class="col-sm-6 content-image" style="background-image: url({{ .Params.image }})">
   </div>
+  <div class="col-sm-6 content-excerpt">
   {{ else }}
-  <div class="row content">
-    {{ if and (isset .Params "image") .Params.image }}
-    <div class="col-md-6 content-image" style="background-image: url({{ .Params.image }})">
-    </div>
-    {{ end }}
-
-    {{ if and (isset .Params "image") .Params.image }}
-    <div class="col-md-6 content-excerpt">
-      {{ else }}
-      <div class="col-md-12 content-excerpt">
-        {{end}}
-        <div class="row">
-          <div class="col-md-12">
-            <div class="content-date">
-              {{ .Date.Format "January 06" }}
-            </div>
-            <div class="content-title">
-              <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>
-            </div>
-            <div class="content-summary">
-              <p> {{ .Summary }} </p>
-              <a class="more-link" href="{{ .Permalink }} "> READ THE POST </a>
-            </div>
-          </div>
+  <div class="col-sm-12 content-excerpt">
+  {{ end }}
+    <div class="row">
+      <div class="col-md-12">
+        <div class="row content-date">
+          {{ .Date.Format "January 06" }}
+        </div>
+        <div class="row content-title">
+          <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>
+        </div>
+        <div class="row content-summary">
+          {{ .Summary }}
+          <a class="more-link" href="{{ .Permalink }} ">Read the post</a>
         </div>
       </div>
-
     </div>
-    {{end}}
-    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -6,7 +6,6 @@
 
 <div class="row">
   <div class="col-md-10 category-description">
-
   </div>
 </div>
 

--- a/static/css/style.default.css
+++ b/static/css/style.default.css
@@ -6306,6 +6306,7 @@ body, input, select, button {
     font-size: 0.813em;
     letter-spacing: 0.08em;
     line-height: 1.85em;
+    text-decoration: none;
     margin-right: 0.75em;
     display: inline-block; }
 
@@ -6315,14 +6316,15 @@ body, input, select, button {
   background-color: #fff;
   color: #4d4d4d;
   opacity: 0.8;
-  height: inherit; }
-  .content-excerpt:hover {
-    opacity: 1; }
+  height: inherit;
+  padding: 1.5em 2em;
+  z-index: 5;
+  transition: opacity 0.1s ease; }
 
 .content-column {
   background-color: #fff;
   color: #4d4d4d;
-  opactiy: 0.8;
+  opacity: 0.8;
   word-wrap: break-word; }
 
 .content-column-content {
@@ -6369,19 +6371,28 @@ body, input, select, button {
 
 .content-image {
   margin-bottom: 2.5em;
-  right: -1px;
+  right: 0px;
   height: 100%;
+  width: 50%;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   background-position: 50%;
-  background-size: cover; }
-  .content-image:hover, .content-image:active, .content-image:focus {
-    -webkit-transform: scale(1.05);
-    transform: scale(1.05);
-    -moz-transform: scale(1.05) rotate(0.02deg); }
+  background-size: cover;
+  z-index: 1;
+  transition: all 0.1s ease; }
 
 .content-date {
   padding-top: 3.7em; }
+
+.content {
+  overflow: hidden;
+  margin-bottom: 1.5em; }
+  .content:hover .content-excerpt, .content:active .content-excerpt, .content:focus .content-excerpt {
+    opacity: 1; }
+  .content:hover .content-image, .content:active .content-image, .content:focus .content-image {
+    -webkit-transform: scale(1.05);
+    transform: scale(1.05);
+    -moz-transform: scale(1.05) rotate(0.02deg); }
 
 .entry {
   background: #fff;
@@ -6439,6 +6450,45 @@ body, input, select, button {
 .footer-title, .footer-menu {
   text-align: center; }
 
+@media only screen and (max-width: 768px) {
+  .content-title:after {
+    height: 0.2em; }
+  .main-content {
+    padding: 0; }
+    .main-content .row {
+      margin-left: 0;
+      margin-right: 0; }
+  .social-media-block-footer {
+    text-align: center;
+    margin-top: 0.8em; }
+  .content-summary p {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    height: calc(1.7rem * 6);
+    font-size: 1.7rem; }
+  .content-date {
+    padding-top: 0; }
+  .entry-header {
+    font-size: 2em; }
+  .entry-meta {
+    margin-top: 1em; }
+  .entry-sidebar {
+    color: #4d4d4d;
+    font-size: 0.8em;
+    font-weight: 700;
+    text-align: left;
+    text-transform: uppercase;
+    margin-top: 0;
+    margin-bottom: 1em; }
+    .entry-sidebar .entry-sidebar-title {
+      margin-top: 0.7em; }
+    .entry-sidebar .entry-categories, .entry-sidebar .entry-tags {
+      color: #8c8c8c;
+      text-transform: none;
+      margin-bottom: 0;
+      display: inline-block;
+      padding: 0 0.3em; } }
+
 @media (min-width: 768px) {
   .top-navigation {
     position: relative;
@@ -6460,4 +6510,14 @@ body, input, select, button {
   .menu {
     float: right; }
   .content {
-    height: 384px; } }
+    height: 384px; }
+  .content:nth-child(2n+0) .content-image {
+    float: right; } }
+
+@media only screen and (max-width: 425px) {
+  .content .content-image {
+    width: 100%;
+    height: 25vh;
+    margin-bottom: 0; }
+  .content .content-excerpt {
+    margin-bottom: 0; } }

--- a/static/css/style.default.css
+++ b/static/css/style.default.css
@@ -6306,7 +6306,6 @@ body, input, select, button {
     font-size: 0.813em;
     letter-spacing: 0.08em;
     line-height: 1.85em;
-    text-decoration: none;
     margin-right: 0.75em;
     display: inline-block; }
 
@@ -6390,8 +6389,8 @@ body, input, select, button {
   .content:hover .content-excerpt, .content:active .content-excerpt, .content:focus .content-excerpt {
     opacity: 1; }
   .content:hover .content-image, .content:active .content-image, .content:focus .content-image {
-    -webkit-transform: scale(1.05);
     transform: scale(1.05);
+    -webkit-transform: scale(1.05);
     -moz-transform: scale(1.05) rotate(0.02deg); }
 
 .entry {

--- a/static/scss/main.scss
+++ b/static/scss/main.scss
@@ -50,7 +50,6 @@ body, input, select, button {
     font-size: 0.813em;
     letter-spacing: 0.08em;
     line-height: 1.85em;
-    text-decoration: none;
     margin-right: 0.75em;
     display: inline-block;
   }
@@ -154,8 +153,8 @@ body, input, select, button {
     }
 
     .content-image {
-      -webkit-transform: scale(1.05);
       transform: scale(1.05);
+      -webkit-transform: scale(1.05);
       -moz-transform: scale(1.05) rotate(0.02deg);
     }
   }

--- a/static/scss/main.scss
+++ b/static/scss/main.scss
@@ -50,6 +50,7 @@ body, input, select, button {
     font-size: 0.813em;
     letter-spacing: 0.08em;
     line-height: 1.85em;
+    text-decoration: none;
     margin-right: 0.75em;
     display: inline-block;
   }
@@ -63,15 +64,15 @@ body, input, select, button {
   color: $contentColor;
   opacity: 0.8;
   height: inherit;
-  &:hover {
-    opacity: 1;
-  }
+  padding: 1.5em 2em;
+  z-index: 5;
+  transition: opacity 0.1s ease;
 }
 
 .content-column {
   background-color: $contentBackground;
   color: $contentColor;
-  opactiy: 0.8;
+  opacity: 0.8;
   word-wrap: break-word;
 }
 
@@ -127,22 +128,39 @@ body, input, select, button {
 
 .content-image {
   margin-bottom: 2.5em;
-  right: -1px;
+  right: 0px;
   height: 100%;
+  width: 50%;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   background-position: 50%;
   background-size: cover;
-  &:hover, &:active, &:focus {
-    -webkit-transform: scale(1.05);
-    transform: scale(1.05);
-    -moz-transform: scale(1.05) rotate(0.02deg);
-  }
+  z-index: 1;
+  transition: all 0.1s ease;
 }
 
 .content-date {
   padding-top: 3.7em;
 }
+
+
+.content {
+  overflow: hidden;
+  margin-bottom: 1.5em;
+
+  &:hover, &:active, &:focus {
+    .content-excerpt {
+      opacity: 1;
+    }
+
+    .content-image {
+      -webkit-transform: scale(1.05);
+      transform: scale(1.05);
+      -moz-transform: scale(1.05) rotate(0.02deg);
+    }
+  }
+}
+
 
 .entry {
   background: $contentBackground;
@@ -211,6 +229,67 @@ body, input, select, button {
   text-align: center;
 }
 
+@media only screen and (max-width: $screen-sm-min) {
+  .content-title:after {
+    height: 0.2em;
+  }
+
+  .main-content {
+    padding: 0;
+    .row {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  .social-media-block-footer {
+    text-align: center;
+    margin-top: 0.8em;
+  }
+
+  .content-summary p {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    height: calc(1.7rem * 6);
+    font-size: 1.7rem;
+  }
+
+  .content-date {
+    padding-top: 0;
+  }
+
+  .entry-header {
+    font-size: 2em;
+  }
+
+  .entry-meta {
+    margin-top: 1em;
+  }
+
+  .entry-sidebar {
+    color: $contentColor;
+    font-size: 0.8em;
+    font-weight: 700;
+    text-align: left;
+    text-transform: uppercase;
+
+    .entry-sidebar-title {
+      margin-top: 0.7em;
+    }
+
+    .entry-categories, .entry-tags {
+      color: #8c8c8c;
+      text-transform: none;
+      margin-bottom: 0;
+      display: inline-block;
+      padding: 0 0.3em;
+    }
+
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
+}
+
 @media (min-width: $screen-sm-min) {
   .top-navigation {
     position: relative;
@@ -241,5 +320,22 @@ body, input, select, button {
   .content {
     height: $screen-sm-min/2;
   }
+
+  .content:nth-child(2n+0) .content-image {
+    float: right;
+  }
 }
 
+@media only screen and (max-width: 425px) {
+  .content {
+    .content-image {
+      width: 100%;
+      height: 25vh;
+      margin-bottom: 0;
+    }
+
+    .content-excerpt {
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
Hey, great port of the theme! Appreciate you bringing it to Hugo.

I noticed a few things when working with it, mainly that images became "squashed" on the mobile view:
![screen shot 2017-07-19 at 2 04 58 am](https://user-images.githubusercontent.com/11914327/28359347-b6959e26-6c26-11e7-9d00-d31c2ed4d394.png)

This PR contains a fix for that issue, as well as:

- **Simplify loop in `partials/portfolio.html`**: the images are now alternated left and right via CSS, compared to the previous approach using the Go template loop with mod 2. As a result, the template file is now cleaner and roughly half the size.
- **Improve the hover transitions in `partials/portfoilio.html`**: Referencing the original theme, the image remains hidden outside the bounds of the box when zooming, so this theme now does that as well. Additionally, hovering over anywhere on the row now zooms the image and highlights the text as in the original theme. 
- **Adjust sidebar on mobile in `_default/single.html**: this section now takes up less screen real estate on mobile, keeping the tags inline under their respective headings of Categories and Tags
- **Other minor CSS tweaks, mostly for mobile / tablet view**

Check it out and let me know what you think.
