### PR TITLE
Fix Date.Format calls in templates

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="col-md-12">
       <div class="entry-meta">
-        {{ .Date.Format "January 06" }}
+        {{ .Date.Format "January 02" }}
       </div>
     </div>
   </div>

--- a/layouts/partials/category.html
+++ b/layouts/partials/category.html
@@ -21,7 +21,7 @@
       <div class="row">
         <div class="col-md-12">
           <div class="row content-date">
-            {{ .Date.Format "January 06" }}
+            {{ .Date.Format "January 02" }}
           </div>
           <div class="row content-title">
             <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>
@@ -53,7 +53,7 @@
         <div class="row">
           <div class="col-md-12">
             <div class="content-date">
-              {{ .Date.Format "January 06" }}
+              {{ .Date.Format "January 02" }}
             </div>
             <div class="content-title">
               <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -21,7 +21,7 @@
     <div class="row">
       <div class="col-md-12">
         <div class="row content-date">
-          {{ .Date.Format "January 06" }}
+          {{ .Date.Format "January 02" }}
         </div>
         <div class="row content-title">
           <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>

--- a/layouts/partials/tag.html
+++ b/layouts/partials/tag.html
@@ -21,7 +21,7 @@
       <div class="row">
         <div class="col-md-12">
           <div class="row content-date">
-            {{ .Date.Format "January 06" }}
+            {{ .Date.Format "January 02" }}
           </div>
           <div class="row content-title">
             <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>
@@ -53,7 +53,7 @@
         <div class="row">
           <div class="col-md-12">
             <div class="content-date">
-              {{ .Date.Format "January 06" }}
+              {{ .Date.Format "January 02" }}
             </div>
             <div class="content-title">
               <h2> <a href="{{ .Permalink }} "> {{ .Title }} </a> </h2>


### PR DESCRIPTION
The templates currently call `Date.Format "January 06"`, but they should call `Date.format "January 02"` according to the documentation at https://golang.org/pkg/time/.

Also, [gohugo.io](https://gohugo.io/functions/format/) writes:
![image](https://user-images.githubusercontent.com/5659459/29754131-4a059536-8b7f-11e7-8591-5cad442be538.png)

