### PR TITLE
Existing impl returns and displays the index as oppossed to actual...

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,9 +10,9 @@
 <div class="row">
   <div class="col-md-12 footer-menu">
       <a href="/">Home /</a>
-      {{ range $name, $taxonomy := .Site.Sections }}
-      {{ if ne $name "post" }}
-      <a href="/{{ $name | urlize }}">{{ $name }} / </a>
+      {{ range $name, $taxonomy := .Site.Params.Navlinks }}
+      {{ if ne $taxonomy.name "Home" }}
+      <a href="/{{ $taxonomy.url | urlize }}">{{ $taxonomy.name }} / </a>
       {{ end }}
       {{ end }}
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,10 +8,10 @@
   </div>
   <div class="col-md-6">
     <div class="menu">
-      <a href="/">Home /</a>
-      {{ range $name, $taxonomy := .Site.Sections }}
-      {{ if ne $name "post" }}
-      <a href="/{{ $name | urlize }}">{{ $name }} / </a>
+       <a href="/">Home /</a>
+      {{ range $name, $taxonomy := .Site.Params.Navlinks }}
+      {{ if ne $taxonomy.name "Home" }}
+      <a href="/{{ $taxonomy.url | urlize }}">{{ $taxonomy.name }} / </a>
       {{ end }}
       {{ end }}
     </div>


### PR DESCRIPTION
 Navlinks.  This commit replaces the sections.index with the actual navlinks defined in the conf file.

I noticed the [demo ](https://themes.gohugo.io/theme/hugo-tracks-theme/)displays "Home/ 0/ 1/ 2/" instead of the actual Navlinks:

![image](https://user-images.githubusercontent.com/5209282/35545217-a78d52ba-0533-11e8-9550-7487cfb54b2a.png)

I was able to reproduce it on my page.  Since I'm lazy I decided create a pull request instead of try to describe what is going on.  

There is a side effect related to this commit... Hugo will no longer dynamically create links for new Sections and all sections must be defined in the config file.

Not sure if the side effect is acceptable... check it out.

Thnx, M
